### PR TITLE
Migration Guide

### DIFF
--- a/docs/reference/sdks/migration.md
+++ b/docs/reference/sdks/migration.md
@@ -11,7 +11,6 @@ In June 2020, Algorand introduced the V2 API for `algod` and deprecated the V1 A
 # Update your SDK
 
 ## JavaScript
-### Update
 
 ```bash
 # update using npm
@@ -20,9 +19,9 @@ npm install algosdk
 # verify installed version
 npm list algosdk
 ```
-### Supported Clients by Version
+### REST APIs by SDK Release
 
-| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| SDK Release | Supported V1 APIs | Supported V2 APIs |
 | ----------- | -------------------- | -------------------- |
 | thru algod@1.5.0 | `algod`, `kmd`       | n/a                  |
 | from algod@1.6.1 | `kmd`                | `algod`, `algorand-indexer` |
@@ -32,8 +31,8 @@ npm list algosdk
 <table>
     <tr>
         <th>API</td>
-        <th>V1 Import</td>
-        <th>V2 Import</td>
+        <th>V1 API (deprecated)</td>
+        <th>V2 API (fully supported)</td>
     </tr>
     <tr>
         <td>
@@ -41,22 +40,22 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            const algosdk = require('algosdk'); // deprecated
+            const algosdk = require('algosdk');
             ```
         </td>
         <td>
             ```javascript
-            const algosdk = require('algosdk'); // fully supported
+            const algosdk = require('algosdk');
             ```
         </td>
     </tr>
-    <tr>
+    <!--tr>
         <td>
             kmd
         </td>
         <td>
             ```javascript
-            const algosdk = require('algosdk'); // unchanged
+            const algosdk = require('algosdk');
             ```
         </td>
         <td>
@@ -64,7 +63,7 @@ npm list algosdk
             // not implemented, continue using V1
             ```
         </td>
-    </tr>
+    </tr-->
     <tr>
         <td>
             indexer
@@ -82,7 +81,7 @@ npm list algosdk
     </tr>
 </table>
 
-### Recommended Client Instantiations
+### Client Instantiations
 <table>
     <tr>
         <th>API</td>
@@ -94,7 +93,7 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port); // fully supported
+            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port);
             ```
         </td>
     </tr>
@@ -104,7 +103,7 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port); // unchanged
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
             ```
         </td>
     </tr>
@@ -121,7 +120,6 @@ npm list algosdk
 </table>
 
 ## Python
-### Update
 
 ```bash
 # update using pip
@@ -133,7 +131,7 @@ pip3 list | grep "py-algorand-sdk"
 
 ### Supported Clients by Version
 
-| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| SDK Version | Supported V1 APIs | Supported V2 APIs |
 | ----------- | -------------------- | -------------------- |
 | thru py-algorand-sdk 1.2.1 | `algod`, `kmd`       | n/a                  |
 | from py-algorand-sdk 1.3.0 | `kmd`                | `algod`, `algorand-indexer` |
@@ -143,8 +141,8 @@ pip3 list | grep "py-algorand-sdk"
 <table>
     <tr>
         <th>API</td>
-        <th>V1 Import</td>
-        <th>V2 Import</td>
+        <th>V1 API (deprecated)</td>
+        <th>V2 API (fully supported)</td>
     </tr>
     <tr>
         <td>
@@ -161,7 +159,7 @@ pip3 list | grep "py-algorand-sdk"
             ```
         </td>
     </tr>
-    <tr>
+    <!--tr>
         <td>
             kmd
         </td>
@@ -175,7 +173,7 @@ pip3 list | grep "py-algorand-sdk"
             # not implemented, use V1
             ```
         </td>
-    </tr>
+    </tr-->
     <tr>
         <td>
             indexer
@@ -193,7 +191,7 @@ pip3 list | grep "py-algorand-sdk"
     </tr>
 </table>
 
-### Recommended Client Instantiations
+### Client Instantiations
 <table>
     <tr>
         <th>API</td>
@@ -205,7 +203,7 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            algod_client = algod.AlgodClient(algod_token, algod_address) // fully supported
+            algod_client = algod.AlgodClient(algod_token, algod_address)
             ```
         </td>
     </tr>
@@ -215,7 +213,7 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            algod_client = algod.AlgodClient(algod_token, algod_address) // unchanged
+            algod_client = algod.AlgodClient(algod_token, algod_address)
             ```
         </td>
     </tr>
@@ -232,7 +230,7 @@ pip3 list | grep "py-algorand-sdk"
 </table>
 
 ## Java
-### Update
+
 
 ```
 Maven:
@@ -244,7 +242,7 @@ Maven:
 ```
 ### Supported Clients by Version
 
-| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| SDK Version | Supported V1 APIs | Supported V2 APIs |
 | ----------- | -------------------- | -------------------- |
 | thru java-algorand-sdk 1.3.1 | `algod`, `kmd`       | n/a                  |
 | from java-algorand-sdk 1.4.0 | `kmd`                | `algod`, `algorand-indexer` |
@@ -254,8 +252,8 @@ Maven:
 <table>
     <tr>
         <th>API</td>
-        <th>V1 Import</td>
-        <th>V2 Import</td>
+        <th>V1 API (deprecated)</td>
+        <th>V2 API (fully supported)</td>
     </tr>
     <tr>
         <td>
@@ -263,7 +261,7 @@ Maven:
         </td>
         <td>
             ```java
-            // deprecated:
+           :
             import com.algorand.algosdk.algod.client.AlgodClient;
             import com.algorand.algosdk.algod.client.ApiException;
             import com.algorand.algosdk.algod.client.api.AlgodApi;
@@ -271,18 +269,18 @@ Maven:
         </td>
         <td>
             ```java
-            // fully supported:
+           :
             import com.algorand.algosdk.v2.client.common.AlgodClient;
             ```
         </td>
     </tr>
-    <tr>
+    <!--tr>
         <td>
             kmd
         </td>
         <td>
             ```java
-            // unchanged:
+           :
             import com.algorand.algosdk.kmd.client.KmdClient;
             import com.algorand.algosdk.kmd.client.ApiException;
             import com.algorand.algosdk.kmd.client.api.KmdApi;
@@ -293,7 +291,7 @@ Maven:
             // not implemented, use V1
             ```
         </td>
-    </tr>
+    </tr-->
     <tr>
         <td>
             indexer
@@ -312,7 +310,7 @@ Maven:
     </tr>
 </table>
 
-### Recommended Client Instantiations
+### Client Instantiations
 <table>
     <tr>
         <th>API</td>
@@ -324,7 +322,7 @@ Maven:
         </td>
         <td>
             ```java
-            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port); // fully supported
+            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port);
             ```
         </td>
     </tr>
@@ -334,7 +332,7 @@ Maven:
         </td>
         <td>
             ```java
-            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port); // unchanged
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
             ```
         </td>
     </tr>
@@ -351,7 +349,7 @@ Maven:
 </table>
 
 ## Go
-### Update
+
 
 ```bash
 go get -u github.com/algorand/go-algorand-sdk/...
@@ -360,7 +358,7 @@ make build
 
 ### Supported Clients by Version
 
-| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| SDK Version | Supported V1 APIs | Supported V2 APIs |
 | ----------- | -------------------- | -------------------- |
 | thru go-algorand-sdk 1.3.0 | `algod`, `kmd`       | n/a                  |
 | from go-algorand-sdk 1.4.0 | `kmd`                | `algod`, `algorand-indexer` |
@@ -370,8 +368,8 @@ make build
 <table>
     <tr>
         <th>API</td>
-        <th>V1 Import</td>
-        <th>V2 Import</td>
+        <th>V1 API (deprecated)</td>
+        <th>V2 API (fully supported)</td>
     </tr>
     <tr>
         <td>
@@ -381,18 +379,18 @@ make build
             ```go
             import ( 
                 "github.com/algorand/go-algorand-sdk/client/algod" 
-            ) // deprecated
+            )
             ```
         </td>
         <td>
             ```go
             import ( 
                 "github.com/algorand/go-algorand-sdk/client/v2/algod" 
-            ) // fully supported
+            )
             ```
         </td>
     </tr>
-    <tr>
+    <!--tr>
         <td>
             kmd
         </td>
@@ -400,7 +398,7 @@ make build
             ```go
             import ( 
                 "github.com/algorand/go-algorand-sdk/client/kmd" 
-            ) // unchanged
+            )
             ```
         </td>
         <td>
@@ -408,7 +406,7 @@ make build
             // not implemented, use V1
             ```
         </td>
-    </tr>
+    </tr-->
     <tr>
         <td>
             indexer
@@ -428,7 +426,7 @@ make build
     </tr>
 </table>
 
-### Recommended Client Instantiations
+### Client Instantiations
 <table>
     <tr>
         <th>API</td>
@@ -440,7 +438,7 @@ make build
         </td>
         <td>
             ```go
-            algodClient, err := algod.MakeClient(algodAddress, algodToken) // fully supported
+            algodClient, err := algod.MakeClient(algodAddress, algodToken)
             ```
         </td>
     </tr>
@@ -450,7 +448,7 @@ make build
         </td>
         <td>
             ```go
-            kmdClient, err := kmd.MakeClient(kmdAddress, kmdToken) // unchanged
+            kmdClient, err := kmd.MakeClient(kmdAddress, kmdToken)
             ```
         </td>
     </tr>

--- a/docs/reference/sdks/migration.md
+++ b/docs/reference/sdks/migration.md
@@ -46,7 +46,7 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            const algosdk = require('algosdk');
+            const algosdk = require('algosdk'); // fully supported
             ```
         </td>
     </tr>
@@ -56,12 +56,12 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            from algosdk import kmd
+            const algosdk = require('algosdk'); // unchanged
             ```
         </td>
         <td>
             ```javascript
-            // Not implemented, use V1
+            // not implemented, continue using V1
             ```
         </td>
     </tr>
@@ -71,12 +71,12 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            // Not implemented, use V2
+            // not implemented, use V2
             ```
         </td>
         <td>
             ```javascript
-            const algosdk = require('algosdk');
+            const algosdk = require('algosdk'); // new
             ```
         </td>
     </tr>
@@ -94,7 +94,7 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port);
+            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port); // fully supported
             ```
         </td>
     </tr>
@@ -104,7 +104,7 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port); // unchanged
             ```
         </td>
     </tr>
@@ -114,7 +114,7 @@ npm list algosdk
         </td>
         <td>
             ```javascript
-            let indexerClient = new algosdk.Indexer(indexer_token, indexer_server, indexer_port);
+            let indexerClient = new algosdk.Indexer(indexer_token, indexer_server, indexer_port); // new
             ```
         </td>
     </tr>
@@ -157,7 +157,7 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            from algosdk.v2client import algod
+            from algosdk.v2client import algod # fully supported
             ```
         </td>
     </tr>
@@ -167,12 +167,12 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            from algosdk import kmd
+            from algosdk import kmd # unchanged
             ```
         </td>
         <td>
             ```python
-            # Not implemented, use V1
+            # not implemented, use V1
             ```
         </td>
     </tr>
@@ -182,12 +182,12 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            # Not implemented, use V2
+            # not implemented, use V2
             ```
         </td>
         <td>
             ```python
-            from algosdk.v2client import indexer
+            from algosdk.v2client import indexer # new
             ```
         </td>
     </tr>
@@ -205,7 +205,7 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            algod_client = algod.AlgodClient(algod_token, algod_address)
+            algod_client = algod.AlgodClient(algod_token, algod_address) // fully supported
             ```
         </td>
     </tr>
@@ -215,7 +215,7 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            algod_client = algod.AlgodClient(algod_token, algod_address)
+            algod_client = algod.AlgodClient(algod_token, algod_address) // unchanged
             ```
         </td>
     </tr>
@@ -225,7 +225,7 @@ pip3 list | grep "py-algorand-sdk"
         </td>
         <td>
             ```python
-            indexer_client = indexer.IndexerClient(indexer_token, indexer_address)
+            indexer_client = indexer.IndexerClient(indexer_token, indexer_address) //new
             ```
         </td>
     </tr>
@@ -263,6 +263,7 @@ Maven:
         </td>
         <td>
             ```java
+            // deprecated:
             import com.algorand.algosdk.algod.client.AlgodClient;
             import com.algorand.algosdk.algod.client.ApiException;
             import com.algorand.algosdk.algod.client.api.AlgodApi;
@@ -270,6 +271,7 @@ Maven:
         </td>
         <td>
             ```java
+            // fully supported:
             import com.algorand.algosdk.v2.client.common.AlgodClient;
             ```
         </td>
@@ -280,6 +282,7 @@ Maven:
         </td>
         <td>
             ```java
+            // unchanged:
             import com.algorand.algosdk.kmd.client.KmdClient;
             import com.algorand.algosdk.kmd.client.ApiException;
             import com.algorand.algosdk.kmd.client.api.KmdApi;
@@ -287,7 +290,7 @@ Maven:
         </td>
         <td>
             ```java
-            // Not implemented, use V1
+            // not implemented, use V1
             ```
         </td>
     </tr>
@@ -297,11 +300,12 @@ Maven:
         </td>
         <td>
             ```java
-            // Not implemented, use V2
+            // not implemented, use V2
             ```
         </td>
         <td>
             ```java
+            // new:
             import com.algorand.algosdk.v2.client.common.IndexerClient;
             ```
         </td>
@@ -320,7 +324,7 @@ Maven:
         </td>
         <td>
             ```java
-            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port);
+            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port); // fully supported
             ```
         </td>
     </tr>
@@ -330,7 +334,7 @@ Maven:
         </td>
         <td>
             ```java
-            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port); // unchanged
             ```
         </td>
     </tr>
@@ -340,7 +344,7 @@ Maven:
         </td>
         <td>
             ```java
-            let indexerClient = new algosdk.Indexer(indexer_token, indexer_server, indexer_port);
+            let indexerClient = new algosdk.Indexer(indexer_token, indexer_server, indexer_port); // new
             ```
         </td>
     </tr>
@@ -384,7 +388,7 @@ make build
             ```go
             import ( 
                 "github.com/algorand/go-algorand-sdk/client/v2/algod" 
-            )
+            ) // fully supported
             ```
         </td>
     </tr>
@@ -396,12 +400,12 @@ make build
             ```go
             import ( 
                 "github.com/algorand/go-algorand-sdk/client/kmd" 
-            )
+            ) // unchanged
             ```
         </td>
         <td>
             ```go
-            // Not implemented, use V1
+            // not implemented, use V1
             ```
         </td>
     </tr>
@@ -411,14 +415,14 @@ make build
         </td>
         <td>
             ```go
-            // Not implemented, use V2
+            // not implemented, use V2
             ```
         </td>
         <td>
             ```go
             import ( 
                 "github.com/algorand/go-algorand-sdk/client/v2/indexer" 
-            )
+            ) // new
             ```
         </td>
     </tr>
@@ -436,7 +440,7 @@ make build
         </td>
         <td>
             ```go
-            algodClient, err := algod.MakeClient(algodAddress, algodToken)
+            algodClient, err := algod.MakeClient(algodAddress, algodToken) // fully supported
             ```
         </td>
     </tr>
@@ -446,7 +450,7 @@ make build
         </td>
         <td>
             ```go
-            kmdClient, err := kmd.MakeClient(kmdAddress, kmdToken)
+            kmdClient, err := kmd.MakeClient(kmdAddress, kmdToken) // unchanged
             ```
         </td>
     </tr>
@@ -456,7 +460,7 @@ make build
         </td>
         <td>
             ```go
-            indexerClient, err := indexer.MakeClient(indexerAddress, indexerToken)
+            indexerClient, err := indexer.MakeClient(indexerAddress, indexerToken) // new
             ```
         </td>
     </tr>

--- a/docs/reference/sdks/migration.md
+++ b/docs/reference/sdks/migration.md
@@ -2,11 +2,11 @@ title: API V2 Migration Guide
 
 In June 2020, Algorand introduced the V2 API for `algod` and deprecated the V1 API. Both APIs remain functional to allow developers time to transition their application code to the fully supported V2 endpoints. Simultaneously, Algorand introduced `algorand-indexer` with only a V2 API. Use this guide to update your preferred SDK for V2 client support and then transition your application to use V2 clients for `algod` and `algorand-indexer` where applicable.
 
-!!! information 
-    The `kmd` API remains unchanged at V1. There are no changes required for application code using the V1 `kmd` client. 
-
 !!! warning
     The deprecation of the V1 API for `algod` will become a breaking change in a future release of the `algod` software. Please ensure your application code is migrated to the new V2 endpoints at this time.
+
+!!! information 
+    The `kmd` API remains unchanged at V1. There are no changes required for application code using the V1 `kmd` client. Reference [kmd client instantiations](#kmd-instantiations) below.
 
 # Update your SDK
 
@@ -97,7 +97,7 @@ npm list algosdk
             ```
         </td>
     </tr>
-    <tr>
+    <!--tr>
         <td>
             kmd
         </td>
@@ -106,7 +106,7 @@ npm list algosdk
             let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
             ```
         </td>
-    </tr>
+    </tr-->
     <tr>
         <td>
             indexer
@@ -200,16 +200,6 @@ pip3 list | grep "py-algorand-sdk"
     <tr>
         <td>
             algod
-        </td>
-        <td>
-            ```python
-            algod_client = algod.AlgodClient(algod_token, algod_address)
-            ```
-        </td>
-    </tr>
-    <tr>
-        <td>
-            kmd
         </td>
         <td>
             ```python
@@ -328,16 +318,6 @@ Maven:
     </tr>
     <tr>
         <td>
-            kmd
-        </td>
-        <td>
-            ```java
-            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
-            ```
-        </td>
-    </tr>
-    <tr>
-        <td>
             indexer
         </td>
         <td>
@@ -444,16 +424,6 @@ make build
     </tr>
     <tr>
         <td>
-            kmd
-        </td>
-        <td>
-            ```go
-            kmdClient, err := kmd.MakeClient(kmdAddress, kmdToken)
-            ```
-        </td>
-    </tr>
-    <tr>
-        <td>
             indexer
         </td>
         <td>
@@ -464,6 +434,53 @@ make build
     </tr>
 </table>
 
-# Update your Application Code
+# kmd Client Instantiations<a name="kmd-instantiations"></a>
+<table>
+    <tr>
+        <th>SDK</td>
+        <th>Client Instantiation</td>
+    </tr>
+    <tr>
+        <td>
+            JavaScript
+        </td>
+        <td>
+            ```javascript
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
+            ```
+        </td>
+    </tr>
+   <tr>
+        <td>
+            Python
+        </td>
+        <td>
+            ```python
+            kmd_client = algod.kmd(kmd_token, kmd_address)
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            Java
+        </td>
+        <td>
+            ```java
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            Go
+        </td>
+        <td>
+            ```go
+            kmdClient, err := kmd.MakeClient(kmdAddress, kmdToken)
+            ```
+        </td>
+    </tr>
+</table>
+
 
 

--- a/docs/reference/sdks/migration.md
+++ b/docs/reference/sdks/migration.md
@@ -1,2 +1,467 @@
-title: V2 Migration Guide
+title: API V2 Migration Guide
+
+In June 2020, Algorand introduced the V2 API for `algod` and deprecated the V1 API. Both APIs remain functional to allow developers time to transition their application code to the fully supported V2 endpoints. Simultaneously, Algorand introduced `algorand-indexer` with only a V2 API. Use this guide to update your preferred SDK for V2 client support and then transition your application to use V2 clients for `algod` and `algorand-indexer` where applicable.
+
+!!! information 
+    The `kmd` API remains unchanged at V1. There are no changes required for application code using the V1 `kmd` client. 
+
+!!! warning
+    The deprecation of the V1 API for `algod` will become a breaking change in a future release of the `algod` software. Please ensure your application code is migrated to the new V2 endpoints at this time.
+
+# Update your SDK
+
+## JavaScript
+### Update
+
+```bash
+# update using npm
+npm install algosdk
+
+# verify installed version
+npm list algosdk
+```
+### Supported Clients by Version
+
+| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| ----------- | -------------------- | -------------------- |
+| thru algod@1.5.0 | `algod`, `kmd`       | n/a                  |
+| from algod@1.6.1 | `kmd`                | `algod`, `algorand-indexer` |
+
+
+### Supported Library Imports
+<table>
+    <tr>
+        <th>API</td>
+        <th>V1 Import</td>
+        <th>V2 Import</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```javascript
+            const algosdk = require('algosdk'); // deprecated
+            ```
+        </td>
+        <td>
+            ```javascript
+            const algosdk = require('algosdk');
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```javascript
+            from algosdk import kmd
+            ```
+        </td>
+        <td>
+            ```javascript
+            // Not implemented, use V1
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```javascript
+            // Not implemented, use V2
+            ```
+        </td>
+        <td>
+            ```javascript
+            const algosdk = require('algosdk');
+            ```
+        </td>
+    </tr>
+</table>
+
+### Recommended Client Instantiations
+<table>
+    <tr>
+        <th>API</td>
+        <th>Client Instantiation</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```javascript
+            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port);
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```javascript
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```javascript
+            let indexerClient = new algosdk.Indexer(indexer_token, indexer_server, indexer_port);
+            ```
+        </td>
+    </tr>
+</table>
+
+## Python
+### Update
+
+```bash
+# update using pip
+pip3 install py-algorand-sdk
+
+# verify installed version
+pip3 list | grep "py-algorand-sdk"
+```
+
+### Supported Clients by Version
+
+| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| ----------- | -------------------- | -------------------- |
+| thru py-algorand-sdk 1.2.1 | `algod`, `kmd`       | n/a                  |
+| from py-algorand-sdk 1.3.0 | `kmd`                | `algod`, `algorand-indexer` |
+
+
+### Supported Library Imports
+<table>
+    <tr>
+        <th>API</td>
+        <th>V1 Import</td>
+        <th>V2 Import</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```python
+            from algosdk import algod # deprecated
+            ```
+        </td>
+        <td>
+            ```python
+            from algosdk.v2client import algod
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```python
+            from algosdk import kmd
+            ```
+        </td>
+        <td>
+            ```python
+            # Not implemented, use V1
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```python
+            # Not implemented, use V2
+            ```
+        </td>
+        <td>
+            ```python
+            from algosdk.v2client import indexer
+            ```
+        </td>
+    </tr>
+</table>
+
+### Recommended Client Instantiations
+<table>
+    <tr>
+        <th>API</td>
+        <th>Client Instantiation</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```python
+            algod_client = algod.AlgodClient(algod_token, algod_address)
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```python
+            algod_client = algod.AlgodClient(algod_token, algod_address)
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```python
+            indexer_client = indexer.IndexerClient(indexer_token, indexer_address)
+            ```
+        </td>
+    </tr>
+</table>
+
+## Java
+### Update
+
+```
+Maven:
+<dependency>
+    <groupId>com.algorand</groupId>
+    <artifactId>algosdk</artifactId>
+    <version>1.4.0</version>
+</dependency>
+```
+### Supported Clients by Version
+
+| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| ----------- | -------------------- | -------------------- |
+| thru java-algorand-sdk 1.3.1 | `algod`, `kmd`       | n/a                  |
+| from java-algorand-sdk 1.4.0 | `kmd`                | `algod`, `algorand-indexer` |
+
+
+### Supported Library Imports
+<table>
+    <tr>
+        <th>API</td>
+        <th>V1 Import</td>
+        <th>V2 Import</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```java
+            import com.algorand.algosdk.algod.client.AlgodClient;
+            import com.algorand.algosdk.algod.client.ApiException;
+            import com.algorand.algosdk.algod.client.api.AlgodApi;
+            ```
+        </td>
+        <td>
+            ```java
+            import com.algorand.algosdk.v2.client.common.AlgodClient;
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```java
+            import com.algorand.algosdk.kmd.client.KmdClient;
+            import com.algorand.algosdk.kmd.client.ApiException;
+            import com.algorand.algosdk.kmd.client.api.KmdApi;
+            ```
+        </td>
+        <td>
+            ```java
+            // Not implemented, use V1
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```java
+            // Not implemented, use V2
+            ```
+        </td>
+        <td>
+            ```java
+            import com.algorand.algosdk.v2.client.common.IndexerClient;
+            ```
+        </td>
+    </tr>
+</table>
+
+### Recommended Client Instantiations
+<table>
+    <tr>
+        <th>API</td>
+        <th>Client Instantiation</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```java
+            let algodClient = new algosdk.Algodv2(algod_token, algod_server, algod_port);
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```java
+            let kmdClient = new algosdk.Kmd(kmd_token, kmd_server, kmd_port);
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```java
+            let indexerClient = new algosdk.Indexer(indexer_token, indexer_server, indexer_port);
+            ```
+        </td>
+    </tr>
+</table>
+
+## Go
+### Update
+
+```bash
+go get -u github.com/algorand/go-algorand-sdk/...
+make build
+```
+
+### Supported Clients by Version
+
+| SDK Version | Supported V1 Clients | Supported V2 Clients |
+| ----------- | -------------------- | -------------------- |
+| thru go-algorand-sdk 1.3.0 | `algod`, `kmd`       | n/a                  |
+| from go-algorand-sdk 1.4.0 | `kmd`                | `algod`, `algorand-indexer` |
+
+
+### Supported Library Imports
+<table>
+    <tr>
+        <th>API</td>
+        <th>V1 Import</td>
+        <th>V2 Import</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```go
+            import ( 
+                "github.com/algorand/go-algorand-sdk/client/algod" 
+            ) // deprecated
+            ```
+        </td>
+        <td>
+            ```go
+            import ( 
+                "github.com/algorand/go-algorand-sdk/client/v2/algod" 
+            )
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```go
+            import ( 
+                "github.com/algorand/go-algorand-sdk/client/kmd" 
+            )
+            ```
+        </td>
+        <td>
+            ```go
+            // Not implemented, use V1
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```go
+            // Not implemented, use V2
+            ```
+        </td>
+        <td>
+            ```go
+            import ( 
+                "github.com/algorand/go-algorand-sdk/client/v2/indexer" 
+            )
+            ```
+        </td>
+    </tr>
+</table>
+
+### Recommended Client Instantiations
+<table>
+    <tr>
+        <th>API</td>
+        <th>Client Instantiation</td>
+    </tr>
+    <tr>
+        <td>
+            algod
+        </td>
+        <td>
+            ```go
+            algodClient, err := algod.MakeClient(algodAddress, algodToken)
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            kmd
+        </td>
+        <td>
+            ```go
+            kmdClient, err := kmd.MakeClient(kmdAddress, kmdToken)
+            ```
+        </td>
+    </tr>
+    <tr>
+        <td>
+            indexer
+        </td>
+        <td>
+            ```go
+            indexerClient, err := indexer.MakeClient(indexerAddress, indexerToken)
+            ```
+        </td>
+    </tr>
+</table>
+
+# Update your Application Code
+
 


### PR DESCRIPTION
New content to assist developers with updating their SDK and transitioning their application for `algod` and `algorand-indexer` V2 client support.